### PR TITLE
清理 BaseContext 的 ThreadLocal 数据以防止数据残留

### DIFF
--- a/hanye-take-out-springboot3/server/src/main/java/fun/cyhgraph/interceptor/JwtTokenAdminInterceptor.java
+++ b/hanye-take-out-springboot3/server/src/main/java/fun/cyhgraph/interceptor/JwtTokenAdminInterceptor.java
@@ -60,4 +60,9 @@ public class JwtTokenAdminInterceptor implements HandlerInterceptor {
         }
     }
 
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        // 清理 ThreadLocal，避免数据残留
+        BaseContext.removeCurrentId();
+    }
 }

--- a/hanye-take-out-springboot3/server/src/main/java/fun/cyhgraph/interceptor/JwtTokenUserInterceptor.java
+++ b/hanye-take-out-springboot3/server/src/main/java/fun/cyhgraph/interceptor/JwtTokenUserInterceptor.java
@@ -59,4 +59,10 @@ public class JwtTokenUserInterceptor implements HandlerInterceptor {
             return false;
         }
     }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        // 清理 ThreadLocal，避免数据残留
+        BaseContext.removeCurrentId();
+    }
 }


### PR DESCRIPTION
在 JwtTokenAdminInterceptor.java 与 JwtTokenUserInterceptor.java 类的 afterCompletion 方法中添加 BaseContext.removeCurrentId() 调用，清理 ThreadLocal 数据，防止数据残留和潜在的内存泄漏。